### PR TITLE
Reduce RAM overhead and thread scalability of assembly in BOSS

### DIFF
--- a/metagraph/experiments/main.cpp
+++ b/metagraph/experiments/main.cpp
@@ -1116,7 +1116,7 @@ int main(int argc, char *argv[]) {
             timer.reset();
 
             // initialize fast query annotation
-            std::vector<BinaryMatrix::SetBitPositions> annotation_rows(num_rows_arg.getValue());
+            Vector<BinaryMatrix::SetBitPositions> annotation_rows(num_rows_arg.getValue());
 
             #pragma omp parallel for num_threads(num_threads) schedule(dynamic)
             for (uint64_t batch_begin = 0;

--- a/metagraph/src/graph/representation/succinct/boss.cpp
+++ b/metagraph/src/graph/representation/succinct/boss.cpp
@@ -2343,11 +2343,8 @@ call_path(const BOSS &boss,
         if (!dual_path[i] || (subgraph_mask && !(*subgraph_mask)[dual_path[i]])
                 || dual_path[i] == path[i]) {
             dual_path[i] = 0;
-            continue;
-        }
-
-        // Check if the reverse-complement k-mer has not been traversed
-        if (!fetch_and_set_bit(visited.data(), dual_path[i], concurrent)) {
+        } else if (!fetch_and_set_bit(visited.data(), dual_path[i], concurrent)) {
+            // Check if the reverse-complement k-mer has not been traversed
             ++progress_bar;
 
             // Add this edge to a list to check if traversal should be

--- a/metagraph/src/graph/representation/succinct/boss.cpp
+++ b/metagraph/src/graph/representation/succinct/boss.cpp
@@ -1838,7 +1838,9 @@ void call_paths(const BOSS &boss,
                 bool trim_sentinels,
                 ThreadPool &thread_pool,
                 sdsl::bit_vector *visited_ptr,
+                sdsl::bit_vector *fetched_ptr,
                 bool async,
+                std::mutex &fetched_mutex,
                 ProgressBar &progress_bar,
                 const bitmap *subgraph_mask);
 
@@ -1858,7 +1860,9 @@ call_path(const BOSS &boss,
           bool kmers_in_single_form,
           bool trim_sentinels,
           sdsl::bit_vector &visited,
+          sdsl::bit_vector &fetched,
           bool concurrent,
+          std::mutex &fetched_mutex,
           ProgressBar &progress_bar,
           const bitmap *subgraph_mask,
           bool is_cycle = false);
@@ -1893,6 +1897,9 @@ void BOSS::call_paths(Call<std::vector<edge_index>&&,
         }
     }
 
+    sdsl::bit_vector fetched = kmers_in_single_form ? visited : sdsl::bit_vector();
+    std::mutex fetched_mutex;
+
     ProgressBar progress_bar(visited.size() - sdsl::util::cnt_one_bits(visited),
                              "Traverse BOSS",
                              std::cerr, !common::get_verbose());
@@ -1906,8 +1913,8 @@ void BOSS::call_paths(Call<std::vector<edge_index>&&,
             ::mtg::graph::boss::call_paths(
                     *this, { start }, callback,
                     split_to_unitigs, select_last_edge, kmers_in_single_form,
-                    trim_sentinels, thread_pool, &visited, async, progress_bar,
-                    subgraph_mask);
+                    trim_sentinels, thread_pool, &visited, &fetched,
+                    async, fetched_mutex, progress_bar, subgraph_mask);
         });
     };
 
@@ -2027,8 +2034,8 @@ void BOSS::call_paths(Call<std::vector<edge_index>&&,
             assert(edge);
         } while (edge != start);
 
-        // If |kmers_in_single_form| = true, extra checks are done to prevent
-        // calling k-mers multiple times.
+        // If |kmers_in_single_form| = true, the edge mask |fetched| is
+        // used in call_path to prevent calling k-mers multiple times.
         // Otherwise, that check has to be done here, so we check the cycle's
         // representative node to see if the cycle has been called already.
         if (!kmers_in_single_form) {
@@ -2044,8 +2051,10 @@ void BOSS::call_paths(Call<std::vector<edge_index>&&,
                 ++progress_bar;
         }
 
-        call_path(*this, callback, path, sequence, kmers_in_single_form, trim_sentinels,
-                  visited, async, progress_bar, subgraph_mask, true); // process cycle
+        call_path(*this, callback, path, sequence,
+                  kmers_in_single_form, trim_sentinels, visited, fetched,
+                  async, fetched_mutex, progress_bar, subgraph_mask,
+                  true); // process cycle
     };
 
     if (!async) {
@@ -2103,10 +2112,12 @@ void call_paths(const BOSS &boss,
                 bool trim_sentinels,
                 ThreadPool &thread_pool,
                 sdsl::bit_vector *visited_ptr,
+                sdsl::bit_vector *fetched_ptr,
                 bool async,
+                std::mutex &fetched_mutex,
                 ProgressBar &progress_bar,
                 const bitmap *subgraph_mask) {
-    assert(visited_ptr);
+    assert(visited_ptr && fetched_ptr);
 
     auto &visited = *visited_ptr;
     // store all branch nodes on the way
@@ -2223,12 +2234,12 @@ void call_paths(const BOSS &boss,
 
             if (edges.size() >= TRAVERSAL_START_BATCH_SIZE - boss.alph_size) {
                 thread_pool.force_enqueue(
-                    [=,&boss,&thread_pool,&progress_bar](std::vector<edge_index> &edges) {
+                    [=,&boss,&thread_pool,&fetched_mutex,&progress_bar](std::vector<edge_index> &edges) {
                         ::mtg::graph::boss::call_paths(
                                 boss, std::move(edges), callback,
                                 split_to_unitigs, select_last_edge, kmers_in_single_form,
-                                trim_sentinels, thread_pool, visited_ptr, async,
-                                progress_bar, subgraph_mask);
+                                trim_sentinels, thread_pool, visited_ptr, fetched_ptr,
+                                async, fetched_mutex, progress_bar, subgraph_mask);
                     },
                     std::vector<edge_index>(edges.begin() + TRAVERSAL_START_BATCH_SIZE / 2,
                                       edges.end())
@@ -2243,8 +2254,8 @@ void call_paths(const BOSS &boss,
 
         auto rev_comp_breakpoints = call_path(
             boss, callback, path, sequence,
-            kmers_in_single_form, trim_sentinels, visited,
-            async, progress_bar, subgraph_mask
+            kmers_in_single_form, trim_sentinels, visited, *fetched_ptr,
+            async, fetched_mutex, progress_bar, subgraph_mask
         );
 
         assert(rev_comp_breakpoints.empty() || kmers_in_single_form);
@@ -2275,7 +2286,9 @@ call_path(const BOSS &boss,
           bool kmers_in_single_form,
           bool trim_sentinels,
           sdsl::bit_vector &visited,
+          sdsl::bit_vector &fetched,
           bool concurrent,
+          std::mutex &fetched_mutex,
           ProgressBar &progress_bar,
           const bitmap *subgraph_mask,
           bool is_cycle) {
@@ -2344,7 +2357,7 @@ call_path(const BOSS &boss,
             // boss.fwd is not called on dual_path[i] to reduce the amount
             // of time spend in the critical section
             dual_endpoints.emplace_back(dual_path[i]);
-        } else {
+        } else if (dual_path[i] != path[i]) {
             if (path_set.find(dual_path[i]) == path_set.end()) {
                 output[i] = 0x00;
             } else if (i > path.size() - i - 1) {
@@ -2353,39 +2366,48 @@ call_path(const BOSS &boss,
         }
     }
 
-    if (is_cycle) {
-        for (size_t i = 0; i < path.size(); ++i) {
-            if (dual_path[i] && !output[i]) {
-                // rotate the loop so we don't cut it if there is an edge visited
-                std::rotate(path.begin(), path.begin() + i, path.end());
-                std::rotate(dual_path.begin(), dual_path.begin() + i, dual_path.end());
-                std::rotate(output.begin(), output.begin() + i, output.end());
+    // fetch all k-mers
+    std::vector<std::pair<size_t, size_t>> ranges;
+    size_t begin = 0;
 
-                // for cycles seq[:k] = seq[-k:]
-                std::rotate(sequence.begin(), sequence.begin() + i, sequence.end() - boss.get_k());
-                std::copy(sequence.begin(), sequence.begin() + boss.get_k(), sequence.end() - boss.get_k());
+    std::ignore = fetched;
+    std::ignore = fetched_mutex;
 
-                break;
+    {
+        if (is_cycle) {
+            for (size_t i = 0; i < path.size(); ++i) {
+                if (dual_path[i] && !output[i]) {
+                    // rotate the loop so we don't cut it if there is an edge visited
+                    std::rotate(path.begin(), path.begin() + i, path.end());
+                    std::rotate(dual_path.begin(), dual_path.begin() + i, dual_path.end());
+                    std::rotate(output.begin(), output.begin() + i, output.end());
+
+                    // for cycles seq[:k] = seq[-k:]
+                    std::rotate(sequence.begin(), sequence.begin() + i, sequence.end() - boss.get_k());
+                    std::copy(sequence.begin(), sequence.begin() + boss.get_k(), sequence.end() - boss.get_k());
+
+                    break;
+                }
             }
         }
-    }
 
-    std::vector<edge_index> breakpoints;
+        // traverse the path with its dual and fetch the nodes
+        for (size_t i = 0; i < path.size(); ++i) {
+            if (output[i])
+                continue;
 
-    // traverse the path with its dual and fetch the nodes
-    for (size_t i = 0; i < path.size(); ++i) {
-        if (!output[i])
-            breakpoints.push_back(i);
-    }
+            // The k-mer or its reverse-complement k-mer had been fetched
+            // -> Skip this k-mer and call the traversed path segment.
+            if (begin < i)
+                ranges.emplace_back(begin, i);
 
-    size_t begin = 0;
-    for (size_t i : breakpoints) {
-        if (begin < i) {
-            callback({ path.begin() + begin, path.begin() + i },
-                     { sequence.begin() + begin, sequence.begin() + i + boss.get_k() });
+            begin = i + 1;
         }
+    }
 
-        begin = i + 1;
+    for (const auto &[a, b] : ranges) {
+        callback({ path.begin() + a, path.begin() + b },
+                 { sequence.begin() + a, sequence.begin() + b + boss.get_k() });
     }
 
     // Call the path traversed

--- a/metagraph/src/graph/representation/succinct/boss.cpp
+++ b/metagraph/src/graph/representation/succinct/boss.cpp
@@ -2127,6 +2127,10 @@ void call_paths(const BOSS &boss,
         std::vector<edge_index> path;
         edge_index edge = edges.back();
         edges.pop_back();
+
+        if (fetch_bit(visited.data(), edge, async))
+            continue;
+
         auto sequence = boss.get_node_seq(edge);
 
         path.reserve(100);

--- a/metagraph/src/graph/representation/succinct/boss.cpp
+++ b/metagraph/src/graph/representation/succinct/boss.cpp
@@ -1838,7 +1838,9 @@ void call_paths(const BOSS &boss,
                 bool trim_sentinels,
                 ThreadPool &thread_pool,
                 sdsl::bit_vector *visited_ptr,
+                sdsl::bit_vector *fetched_ptr,
                 bool async,
+                std::mutex &fetched_mutex,
                 ProgressBar &progress_bar,
                 const bitmap *subgraph_mask);
 
@@ -1858,7 +1860,9 @@ call_path(const BOSS &boss,
           bool kmers_in_single_form,
           bool trim_sentinels,
           sdsl::bit_vector &visited,
+          sdsl::bit_vector &fetched,
           bool concurrent,
+          std::mutex &fetched_mutex,
           ProgressBar &progress_bar,
           const bitmap *subgraph_mask,
           bool is_cycle = false);
@@ -1893,6 +1897,9 @@ void BOSS::call_paths(Call<std::vector<edge_index>&&,
         }
     }
 
+    sdsl::bit_vector fetched = kmers_in_single_form ? visited : sdsl::bit_vector();
+    std::mutex fetched_mutex;
+
     ProgressBar progress_bar(visited.size() - sdsl::util::cnt_one_bits(visited),
                              "Traverse BOSS",
                              std::cerr, !common::get_verbose());
@@ -1906,8 +1913,8 @@ void BOSS::call_paths(Call<std::vector<edge_index>&&,
             ::mtg::graph::boss::call_paths(
                     *this, { start }, callback,
                     split_to_unitigs, select_last_edge, kmers_in_single_form,
-                    trim_sentinels, thread_pool, &visited, async, progress_bar,
-                    subgraph_mask);
+                    trim_sentinels, thread_pool, &visited, &fetched,
+                    async, fetched_mutex, progress_bar, subgraph_mask);
         });
     };
 
@@ -2027,8 +2034,8 @@ void BOSS::call_paths(Call<std::vector<edge_index>&&,
             assert(edge);
         } while (edge != start);
 
-        // If |kmers_in_single_form| = true, extra checks are done to prevent
-        // calling k-mers multiple times.
+        // If |kmers_in_single_form| = true, the edge mask |fetched| is
+        // used in call_path to prevent calling k-mers multiple times.
         // Otherwise, that check has to be done here, so we check the cycle's
         // representative node to see if the cycle has been called already.
         if (!kmers_in_single_form) {
@@ -2044,8 +2051,10 @@ void BOSS::call_paths(Call<std::vector<edge_index>&&,
                 ++progress_bar;
         }
 
-        call_path(*this, callback, path, sequence, kmers_in_single_form, trim_sentinels,
-                  visited, async, progress_bar, subgraph_mask, true); // process cycle
+        call_path(*this, callback, path, sequence,
+                  kmers_in_single_form, trim_sentinels, visited, fetched,
+                  async, fetched_mutex, progress_bar, subgraph_mask,
+                  true); // process cycle
     };
 
     if (!async) {
@@ -2103,10 +2112,12 @@ void call_paths(const BOSS &boss,
                 bool trim_sentinels,
                 ThreadPool &thread_pool,
                 sdsl::bit_vector *visited_ptr,
+                sdsl::bit_vector *fetched_ptr,
                 bool async,
+                std::mutex &fetched_mutex,
                 ProgressBar &progress_bar,
                 const bitmap *subgraph_mask) {
-    assert(visited_ptr);
+    assert(visited_ptr && fetched_ptr);
 
     auto &visited = *visited_ptr;
     // store all branch nodes on the way
@@ -2223,12 +2234,12 @@ void call_paths(const BOSS &boss,
 
             if (edges.size() >= TRAVERSAL_START_BATCH_SIZE - boss.alph_size) {
                 thread_pool.force_enqueue(
-                    [=,&boss,&thread_pool,&progress_bar](std::vector<edge_index> &edges) {
+                    [=,&boss,&thread_pool,&fetched_mutex,&progress_bar](std::vector<edge_index> &edges) {
                         ::mtg::graph::boss::call_paths(
                                 boss, std::move(edges), callback,
                                 split_to_unitigs, select_last_edge, kmers_in_single_form,
-                                trim_sentinels, thread_pool, visited_ptr, async,
-                                progress_bar, subgraph_mask);
+                                trim_sentinels, thread_pool, visited_ptr, fetched_ptr,
+                                async, fetched_mutex, progress_bar, subgraph_mask);
                     },
                     std::vector<edge_index>(edges.begin() + TRAVERSAL_START_BATCH_SIZE / 2,
                                       edges.end())
@@ -2243,8 +2254,8 @@ void call_paths(const BOSS &boss,
 
         auto rev_comp_breakpoints = call_path(
             boss, callback, path, sequence,
-            kmers_in_single_form, trim_sentinels, visited,
-            async, progress_bar, subgraph_mask
+            kmers_in_single_form, trim_sentinels, visited, *fetched_ptr,
+            async, fetched_mutex, progress_bar, subgraph_mask
         );
 
         assert(rev_comp_breakpoints.empty() || kmers_in_single_form);
@@ -2275,7 +2286,9 @@ call_path(const BOSS &boss,
           bool kmers_in_single_form,
           bool trim_sentinels,
           sdsl::bit_vector &visited,
+          sdsl::bit_vector &fetched,
           bool concurrent,
+          std::mutex &fetched_mutex,
           ProgressBar &progress_bar,
           const bitmap *subgraph_mask,
           bool is_cycle) {
@@ -2363,39 +2376,48 @@ call_path(const BOSS &boss,
         }
     }
 
-    if (is_cycle) {
-        for (size_t i = 0; i < path.size(); ++i) {
-            if (dual_path[i] && !output[i]) {
-                // rotate the loop so we don't cut it if there is an edge visited
-                std::rotate(path.begin(), path.begin() + i, path.end());
-                std::rotate(dual_path.begin(), dual_path.begin() + i, dual_path.end());
-                std::rotate(output.begin(), output.begin() + i, output.end());
+    // fetch all k-mers
+    std::vector<std::pair<size_t, size_t>> ranges;
+    size_t begin = 0;
 
-                // for cycles seq[:k] = seq[-k:]
-                std::rotate(sequence.begin(), sequence.begin() + i, sequence.end() - boss.get_k());
-                std::copy(sequence.begin(), sequence.begin() + boss.get_k(), sequence.end() - boss.get_k());
+    std::ignore = fetched;
+    std::ignore = fetched_mutex;
 
-                break;
+    {
+        if (is_cycle) {
+            for (size_t i = 0; i < path.size(); ++i) {
+                if (dual_path[i] && !output[i]) {
+                    // rotate the loop so we don't cut it if there is an edge visited
+                    std::rotate(path.begin(), path.begin() + i, path.end());
+                    std::rotate(dual_path.begin(), dual_path.begin() + i, dual_path.end());
+                    std::rotate(output.begin(), output.begin() + i, output.end());
+
+                    // for cycles seq[:k] = seq[-k:]
+                    std::rotate(sequence.begin(), sequence.begin() + i, sequence.end() - boss.get_k());
+                    std::copy(sequence.begin(), sequence.begin() + boss.get_k(), sequence.end() - boss.get_k());
+
+                    break;
+                }
             }
         }
-    }
 
-    std::vector<edge_index> breakpoints;
+        // traverse the path with its dual and fetch the nodes
+        for (size_t i = 0; i < path.size(); ++i) {
+            if (output[i])
+                continue;
 
-    // traverse the path with its dual and fetch the nodes
-    for (size_t i = 0; i < path.size(); ++i) {
-        if (!output[i])
-            breakpoints.push_back(i);
-    }
+            // The k-mer or its reverse-complement k-mer had been fetched
+            // -> Skip this k-mer and call the traversed path segment.
+            if (begin < i)
+                ranges.emplace_back(begin, i);
 
-    size_t begin = 0;
-    for (size_t i : breakpoints) {
-        if (begin < i) {
-            callback({ path.begin() + begin, path.begin() + i },
-                     { sequence.begin() + begin, sequence.begin() + i + boss.get_k() });
+            begin = i + 1;
         }
+    }
 
-        begin = i + 1;
+    for (const auto &[a, b] : ranges) {
+        callback({ path.begin() + a, path.begin() + b },
+                 { sequence.begin() + a, sequence.begin() + b + boss.get_k() });
     }
 
     // Call the path traversed

--- a/metagraph/src/graph/representation/succinct/boss.cpp
+++ b/metagraph/src/graph/representation/succinct/boss.cpp
@@ -5,6 +5,7 @@
 #include <stack>
 #include <algorithm>
 #include <string>
+#include <unordered_set>
 #include <cstdio>
 #include <cmath>
 
@@ -2325,6 +2326,9 @@ call_path(const BOSS &boss,
         return {};
     }
 
+    std::unordered_set<edge_index> path_set(path.begin(), path.end());
+    std::vector<uint8_t> output(path.size(), 0xFF);
+
     // get dual path (mapping of the reverse complement sequence)
     auto rev_comp_seq = sequence;
     kmer::KmerExtractorBOSS::reverse_complement(&rev_comp_seq);
@@ -2343,6 +2347,7 @@ call_path(const BOSS &boss,
         if (!dual_path[i] || (subgraph_mask && !(*subgraph_mask)[dual_path[i]])
                 || dual_path[i] == path[i]) {
             dual_path[i] = 0;
+
         } else if (!fetch_and_set_bit(visited.data(), dual_path[i], concurrent)) {
             // Check if the reverse-complement k-mer has not been traversed
             ++progress_bar;
@@ -2352,6 +2357,12 @@ call_path(const BOSS &boss,
             // boss.fwd is not called on dual_path[i] to reduce the amount
             // of time spend in the critical section
             dual_endpoints.emplace_back(dual_path[i]);
+        } else if (dual_path[i] != path[i]) {
+            if (path_set.find(dual_path[i]) == path_set.end()) {
+                output[i] = 0x00;
+            } else if (i > path.size() - i - 1) {
+                output[i] = 0x00;
+            }
         }
     }
 
@@ -2359,15 +2370,17 @@ call_path(const BOSS &boss,
     std::vector<std::pair<size_t, size_t>> ranges;
     size_t begin = 0;
 
-    {
-        std::unique_lock<std::mutex> lock(fetched_mutex);
+    std::ignore = fetched;
+    std::ignore = fetched_mutex;
 
+    {
         if (is_cycle) {
             for (size_t i = 0; i < path.size(); ++i) {
-                if (dual_path[i] && fetched[dual_path[i]]) {
+                if (dual_path[i] && !output[i]) {
                     // rotate the loop so we don't cut it if there is an edge visited
                     std::rotate(path.begin(), path.begin() + i, path.end());
                     std::rotate(dual_path.begin(), dual_path.begin() + i, dual_path.end());
+                    std::rotate(output.begin(), output.begin() + i, output.end());
 
                     // for cycles seq[:k] = seq[-k:]
                     std::rotate(sequence.begin(), sequence.begin() + i, sequence.end() - boss.get_k());
@@ -2380,21 +2393,8 @@ call_path(const BOSS &boss,
 
         // traverse the path with its dual and fetch the nodes
         for (size_t i = 0; i < path.size(); ++i) {
-            if (!fetched[path[i]]) {
-                fetched[path[i]] = true;
-
-                // Extend the path if the reverse-complement k-mer was discarded
-                // (if it is not present in the (sub)graph or if it is equal to the
-                // forward k-mer)
-                if (!dual_path[i])
-                    continue;
-
-                // Check if the reverse-complement k-mer has been fetched/called
-                if (!fetched[dual_path[i]]) {
-                    fetched[dual_path[i]] = true;
-                    continue;
-                }
-            }
+            if (output[i])
+                continue;
 
             // The k-mer or its reverse-complement k-mer had been fetched
             // -> Skip this k-mer and call the traversed path segment.

--- a/metagraph/src/graph/representation/succinct/boss.cpp
+++ b/metagraph/src/graph/representation/succinct/boss.cpp
@@ -1838,9 +1838,7 @@ void call_paths(const BOSS &boss,
                 bool trim_sentinels,
                 ThreadPool &thread_pool,
                 sdsl::bit_vector *visited_ptr,
-                sdsl::bit_vector *fetched_ptr,
                 bool async,
-                std::mutex &fetched_mutex,
                 ProgressBar &progress_bar,
                 const bitmap *subgraph_mask);
 
@@ -1860,9 +1858,7 @@ call_path(const BOSS &boss,
           bool kmers_in_single_form,
           bool trim_sentinels,
           sdsl::bit_vector &visited,
-          sdsl::bit_vector &fetched,
           bool concurrent,
-          std::mutex &fetched_mutex,
           ProgressBar &progress_bar,
           const bitmap *subgraph_mask,
           bool is_cycle = false);
@@ -1897,9 +1893,6 @@ void BOSS::call_paths(Call<std::vector<edge_index>&&,
         }
     }
 
-    sdsl::bit_vector fetched = kmers_in_single_form ? visited : sdsl::bit_vector();
-    std::mutex fetched_mutex;
-
     ProgressBar progress_bar(visited.size() - sdsl::util::cnt_one_bits(visited),
                              "Traverse BOSS",
                              std::cerr, !common::get_verbose());
@@ -1913,8 +1906,8 @@ void BOSS::call_paths(Call<std::vector<edge_index>&&,
             ::mtg::graph::boss::call_paths(
                     *this, { start }, callback,
                     split_to_unitigs, select_last_edge, kmers_in_single_form,
-                    trim_sentinels, thread_pool, &visited, &fetched,
-                    async, fetched_mutex, progress_bar, subgraph_mask);
+                    trim_sentinels, thread_pool, &visited, async, progress_bar,
+                    subgraph_mask);
         });
     };
 
@@ -2034,8 +2027,8 @@ void BOSS::call_paths(Call<std::vector<edge_index>&&,
             assert(edge);
         } while (edge != start);
 
-        // If |kmers_in_single_form| = true, the edge mask |fetched| is
-        // used in call_path to prevent calling k-mers multiple times.
+        // If |kmers_in_single_form| = true, extra checks are done to prevent
+        // calling k-mers multiple times.
         // Otherwise, that check has to be done here, so we check the cycle's
         // representative node to see if the cycle has been called already.
         if (!kmers_in_single_form) {
@@ -2051,10 +2044,8 @@ void BOSS::call_paths(Call<std::vector<edge_index>&&,
                 ++progress_bar;
         }
 
-        call_path(*this, callback, path, sequence,
-                  kmers_in_single_form, trim_sentinels, visited, fetched,
-                  async, fetched_mutex, progress_bar, subgraph_mask,
-                  true); // process cycle
+        call_path(*this, callback, path, sequence, kmers_in_single_form, trim_sentinels,
+                  visited, async, progress_bar, subgraph_mask, true); // process cycle
     };
 
     if (!async) {
@@ -2112,12 +2103,10 @@ void call_paths(const BOSS &boss,
                 bool trim_sentinels,
                 ThreadPool &thread_pool,
                 sdsl::bit_vector *visited_ptr,
-                sdsl::bit_vector *fetched_ptr,
                 bool async,
-                std::mutex &fetched_mutex,
                 ProgressBar &progress_bar,
                 const bitmap *subgraph_mask) {
-    assert(visited_ptr && fetched_ptr);
+    assert(visited_ptr);
 
     auto &visited = *visited_ptr;
     // store all branch nodes on the way
@@ -2234,12 +2223,12 @@ void call_paths(const BOSS &boss,
 
             if (edges.size() >= TRAVERSAL_START_BATCH_SIZE - boss.alph_size) {
                 thread_pool.force_enqueue(
-                    [=,&boss,&thread_pool,&fetched_mutex,&progress_bar](std::vector<edge_index> &edges) {
+                    [=,&boss,&thread_pool,&progress_bar](std::vector<edge_index> &edges) {
                         ::mtg::graph::boss::call_paths(
                                 boss, std::move(edges), callback,
                                 split_to_unitigs, select_last_edge, kmers_in_single_form,
-                                trim_sentinels, thread_pool, visited_ptr, fetched_ptr,
-                                async, fetched_mutex, progress_bar, subgraph_mask);
+                                trim_sentinels, thread_pool, visited_ptr, async,
+                                progress_bar, subgraph_mask);
                     },
                     std::vector<edge_index>(edges.begin() + TRAVERSAL_START_BATCH_SIZE / 2,
                                       edges.end())
@@ -2254,8 +2243,8 @@ void call_paths(const BOSS &boss,
 
         auto rev_comp_breakpoints = call_path(
             boss, callback, path, sequence,
-            kmers_in_single_form, trim_sentinels, visited, *fetched_ptr,
-            async, fetched_mutex, progress_bar, subgraph_mask
+            kmers_in_single_form, trim_sentinels, visited,
+            async, progress_bar, subgraph_mask
         );
 
         assert(rev_comp_breakpoints.empty() || kmers_in_single_form);
@@ -2286,9 +2275,7 @@ call_path(const BOSS &boss,
           bool kmers_in_single_form,
           bool trim_sentinels,
           sdsl::bit_vector &visited,
-          sdsl::bit_vector &fetched,
           bool concurrent,
-          std::mutex &fetched_mutex,
           ProgressBar &progress_bar,
           const bitmap *subgraph_mask,
           bool is_cycle) {
@@ -2357,7 +2344,7 @@ call_path(const BOSS &boss,
             // boss.fwd is not called on dual_path[i] to reduce the amount
             // of time spend in the critical section
             dual_endpoints.emplace_back(dual_path[i]);
-        } else if (dual_path[i] != path[i]) {
+        } else {
             if (path_set.find(dual_path[i]) == path_set.end()) {
                 output[i] = 0x00;
             } else if (i > path.size() - i - 1) {
@@ -2366,48 +2353,39 @@ call_path(const BOSS &boss,
         }
     }
 
-    // fetch all k-mers
-    std::vector<std::pair<size_t, size_t>> ranges;
-    size_t begin = 0;
-
-    std::ignore = fetched;
-    std::ignore = fetched_mutex;
-
-    {
-        if (is_cycle) {
-            for (size_t i = 0; i < path.size(); ++i) {
-                if (dual_path[i] && !output[i]) {
-                    // rotate the loop so we don't cut it if there is an edge visited
-                    std::rotate(path.begin(), path.begin() + i, path.end());
-                    std::rotate(dual_path.begin(), dual_path.begin() + i, dual_path.end());
-                    std::rotate(output.begin(), output.begin() + i, output.end());
-
-                    // for cycles seq[:k] = seq[-k:]
-                    std::rotate(sequence.begin(), sequence.begin() + i, sequence.end() - boss.get_k());
-                    std::copy(sequence.begin(), sequence.begin() + boss.get_k(), sequence.end() - boss.get_k());
-
-                    break;
-                }
-            }
-        }
-
-        // traverse the path with its dual and fetch the nodes
+    if (is_cycle) {
         for (size_t i = 0; i < path.size(); ++i) {
-            if (output[i])
-                continue;
+            if (dual_path[i] && !output[i]) {
+                // rotate the loop so we don't cut it if there is an edge visited
+                std::rotate(path.begin(), path.begin() + i, path.end());
+                std::rotate(dual_path.begin(), dual_path.begin() + i, dual_path.end());
+                std::rotate(output.begin(), output.begin() + i, output.end());
 
-            // The k-mer or its reverse-complement k-mer had been fetched
-            // -> Skip this k-mer and call the traversed path segment.
-            if (begin < i)
-                ranges.emplace_back(begin, i);
+                // for cycles seq[:k] = seq[-k:]
+                std::rotate(sequence.begin(), sequence.begin() + i, sequence.end() - boss.get_k());
+                std::copy(sequence.begin(), sequence.begin() + boss.get_k(), sequence.end() - boss.get_k());
 
-            begin = i + 1;
+                break;
+            }
         }
     }
 
-    for (const auto &[a, b] : ranges) {
-        callback({ path.begin() + a, path.begin() + b },
-                 { sequence.begin() + a, sequence.begin() + b + boss.get_k() });
+    std::vector<edge_index> breakpoints;
+
+    // traverse the path with its dual and fetch the nodes
+    for (size_t i = 0; i < path.size(); ++i) {
+        if (!output[i])
+            breakpoints.push_back(i);
+    }
+
+    size_t begin = 0;
+    for (size_t i : breakpoints) {
+        if (begin < i) {
+            callback({ path.begin() + begin, path.begin() + i },
+                     { sequence.begin() + begin, sequence.begin() + i + boss.get_k() });
+        }
+
+        begin = i + 1;
     }
 
     // Call the path traversed


### PR DESCRIPTION
Change log
1) Compute k-mer sequences on-the-fly rather than storing them in a queue
2) Reduce the weight of the critical section in primary contig assembly by visiting all reverse complement k-mers before entering the critical section
3) Store the BOSS edge ranges fetched in the critical section so that the callbacks can be called after unlocking